### PR TITLE
feat: add jira ingestion MVP infrastructure and service

### DIFF
--- a/rag-aws/.flake8
+++ b/rag-aws/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203,W503
+exclude = .venv,build

--- a/rag-aws/.github/workflows/ci.yaml
+++ b/rag-aws/.github/workflows/ci.yaml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -r services/ingest/jira_ingestor/requirements.txt
+          .venv/bin/pip install black isort flake8 mypy bandit pytest boto3
+
+      - name: Lint
+        run: |
+          make lint
+        working-directory: .
+
+      - name: Test
+        run: |
+          make test
+        working-directory: .
+
+      - name: Terraform fmt
+        run: terraform -chdir=infra fmt -check
+
+      - name: Terraform plan
+        run: |
+          terraform -chdir=infra init
+          terraform -chdir=infra plan -lock=false

--- a/rag-aws/.gitignore
+++ b/rag-aws/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+__pycache__/
+build/
+*.zip
+jira_ingestor.zip
+.pytest_cache/
+.terraform/
+terraform.tfstate*

--- a/rag-aws/.pre-commit-config.yaml
+++ b/rag-aws/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        additional_dependencies: ["click<9"]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/rag-aws/Makefile
+++ b/rag-aws/Makefile
@@ -1,0 +1,57 @@
+PYTHON ?= python3
+VENV := .venv
+BIN := $(VENV)/bin
+PACKAGE_DIR := services/ingest/jira_ingestor
+LAMBDA_ZIP := $(PACKAGE_DIR)/jira_ingestor.zip
+BUILD_DIR := build
+TF_DIR := infra
+TF ?= terraform
+TF_ARGS ?=
+DEV_PACKAGES := black isort flake8 mypy bandit pytest boto3 types-requests types-python-dateutil
+
+.PHONY: venv build clean clean-build lint test tf-init tf-plan tf-apply tf-destroy deploy
+
+venv:
+	@if [ ! -d $(VENV) ]; then $(PYTHON) -m venv $(VENV); fi
+	$(BIN)/pip install --upgrade pip
+	$(BIN)/pip install -r $(PACKAGE_DIR)/requirements.txt
+	$(BIN)/pip install $(DEV_PACKAGES)
+
+clean:
+	rm -rf $(VENV) $(BUILD_DIR) $(PACKAGE_DIR)/__pycache__ $(PACKAGE_DIR)/tests/__pycache__
+	rm -f $(LAMBDA_ZIP)
+
+clean-build:
+	rm -rf $(BUILD_DIR)
+	rm -f $(LAMBDA_ZIP)
+
+build: venv clean-build
+	mkdir -p $(BUILD_DIR)
+	$(BIN)/pip install -r $(PACKAGE_DIR)/requirements.txt -t $(BUILD_DIR)
+	cp $(PACKAGE_DIR)/handler.py $(PACKAGE_DIR)/jira_api.py $(PACKAGE_DIR)/adf_md.py $(PACKAGE_DIR)/__init__.py $(BUILD_DIR)/
+	find $(BUILD_DIR) -name "__pycache__" -type d -exec rm -rf {} +
+	cd $(BUILD_DIR) && zip -r ../$(LAMBDA_ZIP) .
+
+lint: venv
+	$(BIN)/black --check $(PACKAGE_DIR) infra
+	$(BIN)/isort --check-only $(PACKAGE_DIR) infra
+	$(BIN)/flake8 $(PACKAGE_DIR)
+	$(BIN)/mypy $(PACKAGE_DIR)
+	$(BIN)/bandit -q -r $(PACKAGE_DIR) -x $(PACKAGE_DIR)/tests
+
+test: venv
+	PYTHONPATH=$(PWD) $(BIN)/pytest -q $(PACKAGE_DIR)/tests
+
+tf-init:
+	cd $(TF_DIR) && $(TF) init
+
+tf-plan:
+	cd $(TF_DIR) && $(TF) plan $(TF_ARGS)
+
+tf-apply:
+	cd $(TF_DIR) && $(TF) apply $(TF_ARGS)
+
+tf-destroy:
+	cd $(TF_DIR) && $(TF) destroy $(TF_ARGS)
+
+deploy: build tf-apply

--- a/rag-aws/README.md
+++ b/rag-aws/README.md
@@ -1,0 +1,150 @@
+# TeamOps Insights — Jira Ingestion MVP
+
+This repository contains a production-focused Retrieval-Augmented Generation (RAG) ingestion
+pipeline that pulls Jira issues and stores both raw and normalized artifacts in Amazon S3. The
+initial milestone is a Jira-only incremental sync that can be deployed quickly with Terraform and
+extended later for chunking, indexing, and retrieval components.
+
+## Architecture Overview
+
+```
++---------------------+        rate(1 hour)         +--------------------+
+|  EventBridge Rule   | --------------------------> |  Lambda Ingestor   |
++---------------------+                             +---------+----------+
+                                                            |
+                                                            v
+                                                  +--------------------+
+                                                  |        S3          |
+                                                  |  raw / normalized  |
+                                                  +--------------------+
+                                                            |
+                                                            v
+                                            +----------------------------+
+                                            |  SSM Parameter Store (cursor) |
+                                            +----------------------------+
+                                                            |
+                                                            v
+                                               +----------------------+
+                                               |  Secrets Manager     |
+                                               |  Jira OAuth secrets  |
+                                               +----------------------+
+```
+
+The Lambda function runs on a schedule (default hourly) and performs the following tasks:
+
+1. Fetches OAuth client credentials and refresh tokens from AWS Secrets Manager.
+2. Retrieves the most recent synchronization cursor from AWS Systems Manager Parameter Store.
+3. Calls Jira's REST API using OAuth 3LO to fetch updated issues, handling pagination, rate
+   limits, and custom field discovery.
+4. Persists the raw JSON payload for each issue to S3 under `raw/jira/<ISSUE KEY>/` and a normalized
+   JSON document under `normalized/jira/<ISSUE KEY>.json`.
+5. Updates the cursor in Parameter Store to the latest `updated` timestamp processed.
+
+## Getting Started
+
+You can run these commands from your local machine or from AWS CloudShell. The Terraform project is
+self-contained and deploys everything required for the MVP ingestion pipeline.
+
+### 1. Bootstrap Secrets Manager
+
+Create a Secrets Manager secret named `rag/jira/oauth` (or any name you prefer) containing the Jira
+OAuth refresh token bundle. The JSON structure must look like this:
+
+```json
+{
+  "client_id": "YOUR-OAUTH-CLIENT-ID",
+  "client_secret": "YOUR-OAUTH-CLIENT-SECRET",
+  "refresh_token": "YOUR-REFRESH-TOKEN",
+  "base_url": "https://yourtenant.atlassian.net"
+}
+```
+
+### 2. Build the Lambda Artifact
+
+```bash
+make build
+```
+
+This command installs runtime dependencies, bundles the ingestion service, and creates
+`services/ingest/jira_ingestor/jira_ingestor.zip` for Terraform to upload.
+
+### 3. Deploy the Infrastructure
+
+Run Terraform with your desired variables. The bucket name must be globally unique.
+
+```bash
+terraform -chdir=infra init
+terraform -chdir=infra apply \
+  -var="bucket_name=<unique-bucket-name>" \
+  -var="jira_secret_arn=<arn-of-rag-jira-oauth>" \
+  -var="region=us-west-2"
+```
+
+Alternatively, the Makefile includes wrappers (`make tf-init`, `make tf-plan`, `make tf-apply`).
+
+### 4. Validate the Ingestor
+
+Trigger the Lambda manually after deployment:
+
+```bash
+aws lambda invoke \
+  --function-name rag-jira-ingestor \
+  --cli-binary-format raw-in-base64-out \
+  --payload '{}' \
+  response.json
+```
+
+Inspect the response payload and CloudWatch Logs. You should find raw issue payloads beneath
+`raw/jira/` and normalized outputs under `normalized/jira/` in the configured S3 bucket.
+
+## Troubleshooting
+
+- **401/403 Responses** – Re-authenticate in Jira and ensure the refresh token has `offline_access`,
+  `read:jira-work`, and `read:jira-user` scopes. Confirm the secret JSON is correct and that the
+  Lambda execution role can read it.
+- **S3 or KMS Access Errors** – Make sure the Terraform deployment completed successfully and the
+  Lambda role policies include S3 and KMS permissions for the managed key.
+- **Cursor Not Advancing** – Check the CloudWatch Logs for warnings. The cursor is stored in
+  Parameter Store at `/rag/jira/last_sync` by default. Deleting the parameter forces a 30-day
+  backfill.
+- **Rate Limits** – Jira may return HTTP 429. The ingestor automatically respects `Retry-After`
+  headers and uses exponential backoff for other transient errors, but persistent failures will be
+  logged with error-level context.
+
+## Extending the System
+
+This MVP intentionally isolates the ingestion responsibilities so future work can plug in additional
+capabilities:
+
+- **Chunking and Embedding** – Add a new Lambda or container task that processes normalized issue
+  documents and writes embeddings to a vector database or index.
+- **Retriever Service** – Publish an API Gateway/Lambda pair that orchestrates the RAG flow using the
+  normalized store as ground truth.
+- **Multi-Source Expansion** – Introduce additional ingestion services (Confluence, GitHub, etc.) by
+  following the same packaging pattern and wiring them into the Terraform stack.
+
+## Repository Layout
+
+```
+rag-aws/
+├── Makefile
+├── README.md
+├── infra/
+│   ├── main.tf
+│   ├── outputs.tf
+│   └── variables.tf
+└── services/
+    └── ingest/
+        └── jira_ingestor/
+            ├── adf_md.py
+            ├── handler.py
+            ├── jira_api.py
+            ├── requirements.txt
+            └── tests/
+                ├── test_adf_md.py
+                └── test_normalize.py
+```
+
+Each module is written with maintainability in mind and is covered by linting, typing, and unit
+tests. Continuous integration via GitHub Actions keeps the quality gates active on every push and
+pull request.

--- a/rag-aws/infra/main.tf
+++ b/rag-aws/infra/main.tf
@@ -1,0 +1,177 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_kms_key" "s3" {
+  description             = "KMS key for Jira ingestion bucket encryption"
+  deletion_window_in_days = 7
+}
+
+resource "aws_s3_bucket" "artifacts" {
+  bucket = var.bucket_name
+}
+
+resource "aws_s3_bucket_public_access_block" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "artifacts" {
+  bucket = aws_s3_bucket.artifacts.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.s3.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_object" "lambda_package" {
+  bucket = aws_s3_bucket.artifacts.id
+  key    = var.lambda_zip_key
+  source = var.lambda_local_zip_path
+  etag   = filemd5(var.lambda_local_zip_path)
+}
+
+resource "aws_ssm_parameter" "cursor" {
+  name  = var.cursor_param_name
+  type  = "String"
+  value = ""
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_iam_role" "lambda" {
+  name = "${var.lambda_name}-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "basic_execution" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "lambda_inline" {
+  name = "${var.lambda_name}-policy"
+  role = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = var.jira_secret_arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameter",
+          "ssm:PutParameter"
+        ]
+        Resource = aws_ssm_parameter.cursor.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:PutObjectAcl"
+        ]
+        Resource = "${aws_s3_bucket.artifacts.arn}/*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Encrypt",
+          "kms:GenerateDataKey"
+        ]
+        Resource = aws_kms_key.s3.arn
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  name              = "/aws/lambda/${var.lambda_name}"
+  retention_in_days = 30
+}
+
+resource "aws_lambda_function" "jira_ingestor" {
+  function_name = var.lambda_name
+  role          = aws_iam_role.lambda.arn
+  handler       = "handler.lambda_handler"
+  runtime       = "python3.12"
+  timeout       = 300
+  memory_size   = 512
+
+  s3_bucket = aws_s3_bucket.artifacts.id
+  s3_key    = aws_s3_object.lambda_package.key
+
+  source_code_hash = filebase64sha256(var.lambda_local_zip_path)
+
+  environment {
+    variables = {
+      S3_BUCKET        = aws_s3_bucket.artifacts.bucket
+      JIRA_OAUTH_SECRET = var.jira_secret_arn
+      CURSOR_PARAM     = var.cursor_param_name
+    }
+  }
+
+  depends_on = [
+    aws_iam_role_policy.lambda_inline,
+    aws_iam_role_policy_attachment.basic_execution
+  ]
+}
+
+resource "aws_cloudwatch_event_rule" "hourly" {
+  name                = "${var.lambda_name}-schedule"
+  description         = "Hourly trigger for Jira ingestion"
+  schedule_expression = "rate(1 hour)"
+}
+
+resource "aws_cloudwatch_event_target" "lambda" {
+  rule      = aws_cloudwatch_event_rule.hourly.name
+  target_id = "jira-ingestor"
+  arn       = aws_lambda_function.jira_ingestor.arn
+}
+
+resource "aws_lambda_permission" "allow_events" {
+  statement_id  = "AllowExecutionFromEventBridge"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.jira_ingestor.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.hourly.arn
+}

--- a/rag-aws/infra/outputs.tf
+++ b/rag-aws/infra/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_name" {
+  description = "S3 bucket storing Jira artifacts and Lambda package"
+  value       = aws_s3_bucket.artifacts.bucket
+}
+
+output "lambda_name" {
+  description = "Name of the Jira ingestion Lambda function"
+  value       = aws_lambda_function.jira_ingestor.function_name
+}
+
+output "event_rule" {
+  description = "CloudWatch Events rule triggering the ingestion Lambda"
+  value       = aws_cloudwatch_event_rule.hourly.name
+}

--- a/rag-aws/infra/variables.tf
+++ b/rag-aws/infra/variables.tf
@@ -1,0 +1,39 @@
+variable "region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "bucket_name" {
+  description = "Unique name for the ingestion artifact bucket"
+  type        = string
+}
+
+variable "jira_secret_arn" {
+  description = "ARN of the Secrets Manager secret containing Jira OAuth credentials"
+  type        = string
+}
+
+variable "lambda_zip_key" {
+  description = "S3 key where the Lambda deployment package will be uploaded"
+  type        = string
+  default     = "lambda/jira_ingestor.zip"
+}
+
+variable "lambda_local_zip_path" {
+  description = "Path to the local Lambda deployment package"
+  type        = string
+  default     = "../../services/ingest/jira_ingestor/jira_ingestor.zip"
+}
+
+variable "lambda_name" {
+  description = "Lambda function name"
+  type        = string
+  default     = "rag-jira-ingestor"
+}
+
+variable "cursor_param_name" {
+  description = "SSM Parameter name used to store the Jira sync cursor"
+  type        = string
+  default     = "/rag/jira/last_sync"
+}

--- a/rag-aws/pyproject.toml
+++ b/rag-aws/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 100
+target-version = ["py312"]
+
+[tool.isort]
+profile = "black"
+line_length = 100
+
+[tool.flake8]
+max-line-length = 100
+extend-ignore = ["E203", "W503"]
+exclude = [
+  ".venv",
+  "build",
+]
+
+[tool.mypy]
+python_version = "3.12"
+ignore_missing_imports = true
+warn_unused_configs = true
+explicit_package_bases = true
+warn_redundant_casts = false
+warn_unused_ignores = false
+strict_optional = false
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["services/ingest/jira_ingestor/tests"]

--- a/rag-aws/services/__init__.py
+++ b/rag-aws/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service packages for ingestion workflows."""

--- a/rag-aws/services/ingest/__init__.py
+++ b/rag-aws/services/ingest/__init__.py
@@ -1,0 +1,1 @@
+"""Ingestion service implementations."""

--- a/rag-aws/services/ingest/jira_ingestor/__init__.py
+++ b/rag-aws/services/ingest/jira_ingestor/__init__.py
@@ -1,0 +1,7 @@
+"""Jira ingestion service package."""
+
+__all__ = [
+    "adf_md",
+    "handler",
+    "jira_api",
+]

--- a/rag-aws/services/ingest/jira_ingestor/adf_md.py
+++ b/rag-aws/services/ingest/jira_ingestor/adf_md.py
@@ -1,0 +1,174 @@
+"""Utilities to convert Atlassian Document Format (ADF) to Markdown."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, List, Optional
+
+
+def to_markdown(adf: Optional[Dict[str, Any]]) -> str:
+    """Render an ADF document to Markdown."""
+
+    if not isinstance(adf, dict):
+        return ""
+
+    content = adf.get("content")
+    if not isinstance(content, list):
+        return ""
+
+    blocks: List[str] = []
+    for node in content:
+        rendered = _render_block(node)
+        if rendered is None:
+            continue
+        blocks.append(rendered.rstrip())
+
+    text = "\n\n".join(blocks)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def _render_block(node: Dict[str, Any], indent: int = 0) -> Optional[str]:
+    node_type = node.get("type")
+    if node_type == "paragraph":
+        return _render_paragraph(node)
+    if node_type == "heading":
+        return _render_heading(node)
+    if node_type == "bulletList":
+        return _render_list(node, indent=indent, ordered=False)
+    if node_type == "orderedList":
+        order = node.get("attrs", {}).get("order", 1)
+        return _render_list(node, indent=indent, ordered=True, start=order)
+    if node_type == "codeBlock":
+        return _render_code_block(node)
+    if node_type == "blockquote":
+        return _render_blockquote(node, indent)
+    if node_type == "rule":
+        return "---"
+    if node_type == "hardBreak":
+        return ""
+    return None
+
+
+def _render_paragraph(node: Dict[str, Any]) -> str:
+    text = _render_inline(node.get("content", []))
+    return text.strip()
+
+
+def _render_heading(node: Dict[str, Any]) -> str:
+    level = node.get("attrs", {}).get("level", 1)
+    try:
+        level = int(level)
+    except (TypeError, ValueError):
+        level = 1
+    level = max(1, min(6, level))
+    text = _render_inline(node.get("content", []))
+    return f"{'#' * level} {text.strip()}"
+
+
+def _render_code_block(node: Dict[str, Any]) -> str:
+    language = node.get("attrs", {}).get("language")
+    code_lines: List[str] = []
+    for child in node.get("content", []):
+        if child.get("type") == "text":
+            code_lines.append(child.get("text", ""))
+    code = "".join(code_lines)
+    fence = f"```{language}" if language else "```"
+    return f"{fence}\n{code}\n```"
+
+
+def _render_blockquote(node: Dict[str, Any], indent: int) -> str:
+    lines: List[str] = []
+    for child in node.get("content", []):
+        rendered = _render_block(child, indent)
+        if not rendered:
+            continue
+        for line in rendered.splitlines():
+            lines.append(f"> {line}" if line else ">")
+    return "\n".join(lines)
+
+
+def _render_list(
+    node: Dict[str, Any],
+    *,
+    indent: int,
+    ordered: bool,
+    start: int = 1,
+) -> str:
+    lines: List[str] = []
+    items: List[Dict[str, Any]] = node.get("content", [])
+    counter = start
+    for item in items:
+        marker = f"{counter}." if ordered else "-"
+        prefix = f"{' ' * indent}{marker} "
+        text_parts: List[str] = []
+        nested_blocks: List[str] = []
+        for child in item.get("content", []):
+            child_type = child.get("type")
+            if child_type == "paragraph":
+                paragraph = _render_inline(child.get("content", []))
+                if paragraph:
+                    text_parts.append(paragraph.replace("\n", " ").strip())
+            elif child_type in {"bulletList", "orderedList"}:
+                nested = _render_list(
+                    child,
+                    indent=indent + 2,
+                    ordered=child_type == "orderedList",
+                    start=child.get("attrs", {}).get("order", 1),
+                )
+                if nested:
+                    nested_blocks.append(nested)
+            else:
+                other = _render_block(child, indent=indent + 2)
+                if other:
+                    text_parts.append(other.strip())
+        line = prefix + " ".join(text_parts).strip()
+        lines.append(line.rstrip())
+        for nested in nested_blocks:
+            lines.extend(nested.splitlines())
+        if ordered:
+            counter += 1
+    return "\n".join(lines)
+
+
+def _render_inline(content: Iterable[Dict[str, Any]]) -> str:
+    parts: List[str] = []
+    for node in content:
+        node_type = node.get("type")
+        if node_type == "text":
+            text = node.get("text", "")
+            for mark in node.get("marks", []):
+                text = _apply_mark(text, mark)
+            parts.append(text)
+        elif node_type == "hardBreak":
+            parts.append("\n")
+        elif node_type == "paragraph":
+            parts.append(_render_paragraph(node))
+        elif node_type == "emoji":
+            short_name = node.get("attrs", {}).get("shortName")
+            if short_name:
+                parts.append(short_name)
+        elif node_type == "mention":
+            attrs = node.get("attrs", {})
+            text = attrs.get("text") or attrs.get("displayName")
+            if text:
+                parts.append(text)
+    return "".join(parts)
+
+
+def _apply_mark(text: str, mark: Dict[str, Any]) -> str:
+    mark_type = mark.get("type")
+    if mark_type == "strong":
+        return f"**{text}**"
+    if mark_type == "em":
+        return f"*{text}*"
+    if mark_type == "code":
+        return f"`{text}`"
+    if mark_type == "link":
+        href = mark.get("attrs", {}).get("href")
+        if href:
+            return f"[{text}]({href})"
+    return text
+
+
+__all__ = ["to_markdown"]

--- a/rag-aws/services/ingest/jira_ingestor/handler.py
+++ b/rag-aws/services/ingest/jira_ingestor/handler.py
@@ -1,0 +1,377 @@
+"""Lambda entrypoint for the Jira ingestion service."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Iterable, List, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+from dateutil import parser as date_parser
+
+from .adf_md import to_markdown
+from .jira_api import (
+    JiraAuthError,
+    JiraRateLimitError,
+    JiraTransientError,
+    discover_field_map,
+    get_all_comments,
+    refresh_access_token,
+    search_page,
+)
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
+
+DEFAULT_LOOKBACK_DAYS = 30
+MAX_ISSUES_PER_RUN = 10_000
+PAGE_SIZE = 100
+PAGE_SLEEP_SECONDS = 0.2
+COMMENT_CAP = 2_000
+
+BASE_FIELDS = [
+    "summary",
+    "description",
+    "comment",
+    "issuelinks",
+    "labels",
+    "components",
+    "fixVersions",
+    "issuetype",
+    "status",
+    "project",
+    "reporter",
+    "assignee",
+    "created",
+    "updated",
+]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _default_cursor() -> str:
+    lookback = _utcnow() - timedelta(days=DEFAULT_LOOKBACK_DAYS)
+    return lookback.strftime("%Y-%m-%d %H:%M")
+
+
+def _parse_updated(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        parsed = date_parser.parse(value)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except (ValueError, TypeError) as exc:
+        LOGGER.warning("Unable to parse Jira timestamp '%s': %s", value, exc)
+        return None
+
+
+def _format_cursor(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M")
+
+
+def _to_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_dict_list(value: Any) -> List[Dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _rich_text_payload(adf: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    return {
+        "adf": adf if isinstance(adf, dict) else None,
+        "markdown": to_markdown(adf if isinstance(adf, dict) else None),
+    }
+
+
+def _normalize_links(links: Iterable[Dict[str, Any]]) -> List[Dict[str, Optional[str]]]:
+    normalized: List[Dict[str, Optional[str]]] = []
+    for link in links or []:
+        link_type = link.get("type", {})
+        outward_issue = link.get("outwardIssue")
+        inward_issue = link.get("inwardIssue")
+        if outward_issue:
+            normalized.append(
+                {
+                    "type": link_type.get("outward") or link_type.get("name"),
+                    "direction": "outward",
+                    "key": outward_issue.get("key"),
+                }
+            )
+        if inward_issue:
+            normalized.append(
+                {
+                    "type": link_type.get("inward") or link_type.get("name"),
+                    "direction": "inward",
+                    "key": inward_issue.get("key"),
+                }
+            )
+    return [link for link in normalized if link.get("key")]
+
+
+def _normalize_comments(comments: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    normalized_comments: List[Dict[str, Any]] = []
+    for comment in comments or []:
+        body = comment.get("body")
+        normalized_comments.append(
+            {
+                "author": (comment.get("author") or {}).get("displayName"),
+                "created": comment.get("created"),
+                "adf": body if isinstance(body, dict) else None,
+                "markdown": to_markdown(body if isinstance(body, dict) else None),
+            }
+        )
+    return normalized_comments
+
+
+def normalize_issue(
+    issue: Dict[str, Any],
+    field_map: Dict[str, Optional[str]],
+    base_url: str,
+    fetched_at: str,
+    *,
+    comments: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """Normalize a Jira issue into the RAG-friendly schema."""
+
+    fields: Dict[str, Any] = issue.get("fields", {})
+    acceptance_field = field_map.get("acceptance_criteria")
+    deployment_field = field_map.get("deployment_notes")
+
+    acceptance_adf = fields.get(acceptance_field) if acceptance_field else None
+    deployment_adf = fields.get(deployment_field) if deployment_field else None
+
+    comment_field = fields.get("comment")
+    if comments is not None:
+        comment_source: List[Dict[str, Any]] = list(comments)
+    elif isinstance(comment_field, dict):
+        comment_source = _as_dict_list(comment_field.get("comments"))
+    else:
+        comment_source = []
+
+    links_data = _as_dict_list(fields.get("issuelinks"))
+    labels_value = fields.get("labels")
+    labels = (
+        [label for label in labels_value if isinstance(label, str)]
+        if isinstance(labels_value, list)
+        else []
+    )
+    component_names = [
+        component.get("name")
+        for component in _as_dict_list(fields.get("components"))
+        if component.get("name")
+    ]
+    fix_versions = [
+        version.get("name")
+        for version in _as_dict_list(fields.get("fixVersions"))
+        if version.get("name")
+    ]
+
+    normalized = {
+        "source": "jira",
+        "key": issue.get("key"),
+        "project": (fields.get("project") or {}).get("key")
+        or (fields.get("project") or {}).get("name"),
+        "issue_type": (fields.get("issuetype") or {}).get("name"),
+        "status": (fields.get("status") or {}).get("name"),
+        "summary": fields.get("summary"),
+        "description": _rich_text_payload(fields.get("description")),
+        "acceptance_criteria": _rich_text_payload(acceptance_adf),
+        "deployment_notes": _rich_text_payload(deployment_adf),
+        "comments": _normalize_comments(comment_source),
+        "links": _normalize_links(links_data),
+        "labels": labels,
+        "components": component_names,
+        "fix_versions": fix_versions,
+        "reporter": (fields.get("reporter") or {}).get("displayName"),
+        "assignee": (fields.get("assignee") or {}).get("displayName"),
+        "created": fields.get("created"),
+        "updated": fields.get("updated"),
+        "uri": f"{base_url.rstrip('/')}/browse/{issue.get('key')}",
+        "fetched_at": fetched_at,
+    }
+    return normalized
+
+
+def _write_json_to_s3(s3_client, bucket: str, key: str, payload: Dict[str, Any]) -> None:
+    body = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
+    s3_client.put_object(Bucket=bucket, Key=key, Body=body, ContentType="application/json")
+
+
+def _load_secret(secret_id: str) -> Dict[str, Any]:
+    secrets_client = boto3.client("secretsmanager")
+    try:
+        response = secrets_client.get_secret_value(SecretId=secret_id)
+    except ClientError as exc:
+        LOGGER.error("Unable to read Jira secret '%s': %s", secret_id, exc)
+        raise
+
+    secret_string = response.get("SecretString")
+    if secret_string:
+        return json.loads(secret_string)
+    raise ValueError("SecretString missing from secrets manager response")
+
+
+def _get_cursor(ssm_client, name: str) -> str:
+    try:
+        response = ssm_client.get_parameter(Name=name)
+        value = response.get("Parameter", {}).get("Value")
+        if value:
+            return value
+    except ssm_client.exceptions.ParameterNotFound:
+        LOGGER.info("Cursor parameter '%s' not found; using default lookback", name)
+    return _default_cursor()
+
+
+def _update_cursor(ssm_client, name: str, value: str) -> None:
+    ssm_client.put_parameter(Name=name, Value=value, Type="String", Overwrite=True)
+
+
+def lambda_handler(event: Optional[Dict[str, Any]], context: Any) -> Dict[str, Any]:
+    """AWS Lambda handler."""
+
+    try:
+        return _run_ingestion()
+    except (JiraAuthError, JiraTransientError, JiraRateLimitError) as exc:
+        LOGGER.error("Jira ingestion failed: %s", exc)
+        raise
+    except Exception:  # pragma: no cover - defensive logging
+        LOGGER.exception("Unexpected error during Jira ingestion")
+        raise
+
+
+def _run_ingestion() -> Dict[str, Any]:
+    s3_bucket = os.environ["S3_BUCKET"]
+    secret_id = os.environ["JIRA_OAUTH_SECRET"]
+    cursor_param = os.environ.get("CURSOR_PARAM", "/rag/jira/last_sync")
+
+    secret = _load_secret(secret_id)
+    client_id = secret["client_id"]
+    client_secret = secret["client_secret"]
+    refresh_token = secret["refresh_token"]
+    base_url = secret["base_url"]
+
+    LOGGER.info("Refreshing Jira access token")
+    access_token = refresh_access_token(client_id, client_secret, refresh_token)
+
+    ssm_client = boto3.client("ssm")
+    cursor = _get_cursor(ssm_client, cursor_param)
+    jql = f'updated >= "{cursor}" ORDER BY updated ASC'
+    LOGGER.info("Using JQL: %s", jql)
+
+    field_map = discover_field_map(base_url, access_token)
+    if not field_map.get("acceptance_criteria"):
+        LOGGER.warning("Acceptance Criteria field not discovered; output will omit this field")
+    if not field_map.get("deployment_notes"):
+        LOGGER.warning("Deployment Notes field not discovered; output will omit this field")
+
+    fields = list(BASE_FIELDS)
+    if field_map.get("acceptance_criteria"):
+        fields.append(field_map["acceptance_criteria"])
+    if field_map.get("deployment_notes"):
+        fields.append(field_map["deployment_notes"])
+    fields_csv = ",".join(fields)
+
+    fetched_at = _utcnow().isoformat().replace("+00:00", "Z")
+    s3_client = boto3.client("s3")
+
+    latest_updated: Optional[datetime] = None
+    issues_processed = 0
+    start_at = 0
+
+    while issues_processed < MAX_ISSUES_PER_RUN:
+        page = search_page(
+            base_url,
+            access_token,
+            jql,
+            fields_csv,
+            start_at=start_at,
+            max_results=PAGE_SIZE,
+        )
+        issues = _as_dict_list(page.get("issues"))
+        total = _to_int(page.get("total"), 0)
+        LOGGER.info("Fetched page startAt=%s count=%s total=%s", start_at, len(issues), total)
+
+        if not issues:
+            break
+
+        for issue in issues:
+            fields_raw = issue.get("fields")
+            fields_data: Dict[str, Any] = fields_raw if isinstance(fields_raw, dict) else {}
+            comment_field = fields_data.get("comment")
+            comment_info: Dict[str, Any] = comment_field if isinstance(comment_field, dict) else {}
+            initial_comments = _as_dict_list(comment_info.get("comments"))
+            total_comments = _to_int(comment_info.get("total"), len(initial_comments))
+            issue_id = issue.get("id")
+            if issue_id is None:
+                LOGGER.warning(
+                    "Issue %s missing id; skipping extended comment fetch", issue.get("key")
+                )
+                all_comments = initial_comments[:COMMENT_CAP]
+                issue_id_str = issue.get("key") or "unknown"
+            else:
+                issue_id_str = str(issue_id)
+                all_comments = get_all_comments(
+                    base_url,
+                    access_token,
+                    issue_id_str,
+                    initial_comments,
+                    total_comments,
+                    max_comments=COMMENT_CAP,
+                )
+            if isinstance(comment_field, dict):
+                comment_field["comments"] = all_comments
+
+            timestamp = _utcnow().strftime("%Y%m%dT%H%M%SZ")
+            issue_key = issue.get("key") or issue_id_str
+            raw_key = f"raw/jira/{issue_key}/{issue_id_str}-{timestamp}.json"
+            _write_json_to_s3(s3_client, s3_bucket, raw_key, issue)
+
+            normalized = normalize_issue(
+                issue,
+                field_map,
+                base_url,
+                fetched_at,
+                comments=all_comments,
+            )
+            normalized_key = f"normalized/jira/{issue_key}.json"
+            _write_json_to_s3(s3_client, s3_bucket, normalized_key, normalized)
+
+            updated_value = _parse_updated(fields_data.get("updated"))
+            if updated_value and (latest_updated is None or updated_value > latest_updated):
+                latest_updated = updated_value
+
+            issues_processed += 1
+            if issues_processed >= MAX_ISSUES_PER_RUN:
+                LOGGER.warning("Reached per-run issue cap of %s", MAX_ISSUES_PER_RUN)
+                break
+
+        start_at += len(issues)
+        if start_at >= total:
+            break
+        time.sleep(PAGE_SLEEP_SECONDS)
+
+    if latest_updated is not None:
+        new_cursor = _format_cursor(latest_updated)
+        _update_cursor(ssm_client, cursor_param, new_cursor)
+    else:
+        new_cursor = cursor
+
+    LOGGER.info("Processed %s issues; cursor now %s", issues_processed, new_cursor)
+    return {"synced_through": new_cursor, "count": issues_processed}
+
+
+__all__ = ["lambda_handler", "normalize_issue"]

--- a/rag-aws/services/ingest/jira_ingestor/jira_api.py
+++ b/rag-aws/services/ingest/jira_ingestor/jira_api.py
@@ -1,0 +1,217 @@
+"""Utilities for interacting with the Jira REST API."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+import requests
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+LOGGER = logging.getLogger(__name__)
+TOKEN_URL = "https://auth.atlassian.com/oauth/token"  # nosec B105
+DEFAULT_TIMEOUT = 30
+MAX_RETRIES = 5
+
+
+class JiraError(Exception):
+    """Base exception for Jira API failures."""
+
+
+class JiraAuthError(JiraError):
+    """Authentication or authorization failure."""
+
+
+class JiraTransientError(JiraError):
+    """Retryable failure returned by Jira."""
+
+
+class JiraRateLimitError(JiraTransientError):
+    """HTTP 429 responses that require waiting before retrying."""
+
+
+def _normalize_synonym(value: str) -> str:
+    return " ".join(value.strip().lower().replace("_", " ").replace("-", " ").split())
+
+
+def _build_url(base_url: str, path: str) -> str:
+    if path.startswith("http://") or path.startswith("https://"):
+        return path
+    base = base_url.rstrip("/")
+    cleaned_path = path.lstrip("/")
+    return f"{base}/{cleaned_path}"
+
+
+@retry(
+    stop=stop_after_attempt(MAX_RETRIES),
+    wait=wait_exponential(multiplier=1, min=1, max=30),
+    retry=retry_if_exception_type(
+        (requests.RequestException, JiraTransientError, JiraRateLimitError)
+    ),
+    reraise=True,
+)
+def _request(
+    method: str,
+    url: str,
+    *,
+    headers: Optional[Dict[str, str]] = None,
+    params: Optional[Mapping[str, Any]] = None,
+    json: Optional[Mapping[str, Any]] = None,
+) -> requests.Response:
+    params_dict = dict(params) if params is not None else None
+    json_dict = dict(json) if json is not None else None
+    response = requests.request(
+        method,
+        url,
+        headers=headers,
+        params=params_dict,
+        json=json_dict,
+        timeout=DEFAULT_TIMEOUT,
+    )
+
+    if response.status_code == 429:
+        retry_after = response.headers.get("Retry-After")
+        sleep_for = 5.0
+        if retry_after:
+            try:
+                sleep_for = float(retry_after)
+            except ValueError:
+                LOGGER.debug("Invalid Retry-After header '%s'", retry_after)
+        LOGGER.info("Hit Jira rate limit, sleeping for %.1fs", sleep_for)
+        time.sleep(sleep_for)
+        raise JiraRateLimitError("Jira rate limit encountered")
+
+    if 500 <= response.status_code < 600:
+        raise JiraTransientError(f"Jira 5xx error: {response.status_code}")
+
+    if response.status_code >= 400:
+        raise JiraAuthError(f"Jira returned HTTP {response.status_code}: {response.text}")
+
+    return response
+
+
+@retry(
+    stop=stop_after_attempt(MAX_RETRIES),
+    wait=wait_exponential(multiplier=1, min=1, max=30),
+    retry=retry_if_exception_type(
+        (requests.RequestException, JiraTransientError, JiraRateLimitError)
+    ),
+    reraise=True,
+)
+def refresh_access_token(client_id: str, client_secret: str, refresh_token: str) -> str:
+    """Exchange a refresh token for a short-lived access token."""
+
+    payload = {
+        "grant_type": "refresh_token",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "refresh_token": refresh_token,
+    }
+
+    response = _request("POST", TOKEN_URL, json=payload)
+    data = response.json()
+    token = data.get("access_token")
+    if not token:
+        raise JiraAuthError("Access token missing in response")
+    return token
+
+
+def jira_get(base_url: str, token: str, path: str, params: Optional[Mapping[str, Any]] = None):
+    """Perform a GET request against the Jira REST API with retry semantics."""
+
+    url = _build_url(base_url, path)
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+
+    response = _request("GET", url, headers=headers, params=params)
+    return response.json()
+
+
+def discover_field_map(
+    base_url: str,
+    token: str,
+    synonyms: Optional[Dict[str, Iterable[str]]] = None,
+) -> Dict[str, Optional[str]]:
+    """Find custom field IDs for the requested synonym sets."""
+
+    synonym_map: Dict[str, Iterable[str]] = synonyms or {
+        "acceptance_criteria": ["acceptance criteria", "acceptance-criteria", "ac", "gherkin"],
+        "deployment_notes": ["deployment notes", "deploy notes", "release notes (tech)"],
+    }
+
+    normalized_targets = {
+        key: {_normalize_synonym(value) for value in values} for key, values in synonym_map.items()
+    }
+
+    discovered: Dict[str, Optional[str]] = {key: None for key in normalized_targets}
+    fields = jira_get(base_url, token, "/rest/api/3/field")
+
+    for field in fields:
+        field_name = str(field.get("name", ""))
+        normalized_name = _normalize_synonym(field_name)
+        field_id = field.get("id") or field.get("key")
+        if not field_id:
+            continue
+        for target, options in normalized_targets.items():
+            if normalized_name in options and not discovered[target]:
+                discovered[target] = str(field_id)
+
+    return discovered
+
+
+def search_page(
+    base_url: str,
+    token: str,
+    jql: str,
+    fields_csv: str,
+    *,
+    start_at: int = 0,
+    max_results: int = 100,
+) -> Dict[str, object]:
+    params: Dict[str, Any] = {
+        "jql": jql,
+        "fields": fields_csv,
+        "startAt": start_at,
+        "maxResults": max_results,
+    }
+    return jira_get(base_url, token, "/rest/api/3/search", params=params)
+
+
+def get_all_comments(
+    base_url: str,
+    token: str,
+    issue_id: str,
+    initial_comments: Optional[List[Dict[str, Any]]],
+    total: int,
+    *,
+    page_size: int = 100,
+    max_comments: int = 2000,
+) -> List[Dict[str, object]]:
+    """Fetch the full comment set for an issue, respecting the configured limits."""
+
+    comments: List[Dict[str, Any]] = list(initial_comments or [])
+    cap = min(total, max_comments)
+    start_at = len(comments)
+
+    while start_at < cap:
+        remaining = cap - start_at
+        fetch_size = min(page_size, remaining)
+        params = {"startAt": start_at, "maxResults": fetch_size}
+        response = jira_get(
+            base_url,
+            token,
+            f"/rest/api/3/issue/{issue_id}/comment",
+            params=params,
+        )
+        new_comments = response.get("comments", [])
+        if not new_comments:
+            break
+        comments.extend(new_comments)
+        start_at = len(comments)
+        if len(new_comments) < fetch_size:
+            break
+
+    return comments[:cap]

--- a/rag-aws/services/ingest/jira_ingestor/requirements.txt
+++ b/rag-aws/services/ingest/jira_ingestor/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.32.0
+python-dateutil>=2.9.0
+tenacity>=8.2.3

--- a/rag-aws/services/ingest/jira_ingestor/tests/test_adf_md.py
+++ b/rag-aws/services/ingest/jira_ingestor/tests/test_adf_md.py
@@ -1,0 +1,149 @@
+import textwrap
+
+from services.ingest.jira_ingestor.adf_md import to_markdown
+
+
+def test_to_markdown_renders_common_nodes():
+    adf = {
+        "type": "doc",
+        "content": [
+            {
+                "type": "heading",
+                "attrs": {"level": 2},
+                "content": [{"type": "text", "text": "Heading"}],
+            },
+            {
+                "type": "paragraph",
+                "content": [
+                    {"type": "text", "text": "This is "},
+                    {
+                        "type": "text",
+                        "text": "bold",
+                        "marks": [{"type": "strong"}],
+                    },
+                    {"type": "text", "text": " and "},
+                    {
+                        "type": "text",
+                        "text": "italic",
+                        "marks": [{"type": "em"}],
+                    },
+                    {"type": "text", "text": " with "},
+                    {
+                        "type": "text",
+                        "text": "code",
+                        "marks": [{"type": "code"}],
+                    },
+                    {"type": "text", "text": " and "},
+                    {
+                        "type": "text",
+                        "text": "a link",
+                        "marks": [
+                            {
+                                "type": "link",
+                                "attrs": {"href": "https://example.com"},
+                            }
+                        ],
+                    },
+                    {"type": "text", "text": "."},
+                ],
+            },
+            {
+                "type": "bulletList",
+                "content": [
+                    {
+                        "type": "listItem",
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [{"type": "text", "text": "First"}],
+                            }
+                        ],
+                    },
+                    {
+                        "type": "listItem",
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [{"type": "text", "text": "Second"}],
+                            }
+                        ],
+                    },
+                ],
+            },
+            {
+                "type": "orderedList",
+                "attrs": {"order": 1},
+                "content": [
+                    {
+                        "type": "listItem",
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [{"type": "text", "text": "One"}],
+                            }
+                        ],
+                    },
+                    {
+                        "type": "listItem",
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [{"type": "text", "text": "Two"}],
+                            }
+                        ],
+                    },
+                ],
+            },
+            {
+                "type": "codeBlock",
+                "attrs": {"language": "python"},
+                "content": [{"type": "text", "text": "print('hello')"}],
+            },
+        ],
+    }
+
+    markdown = to_markdown(adf)
+    assert (
+        markdown
+        == textwrap.dedent(
+            """\
+        ## Heading
+
+        This is **bold** and *italic* with `code` and [a link](https://example.com).
+
+        - First
+        - Second
+
+        1. One
+        2. Two
+
+        ```python
+        print('hello')
+        ```
+        """
+        ).strip()
+    )
+
+
+def test_to_markdown_collapses_empty_nodes():
+    adf = {
+        "type": "doc",
+        "content": [
+            {"type": "paragraph", "content": []},
+            {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": "Hello"}],
+            },
+            {
+                "type": "paragraph",
+                "content": [
+                    {"type": "text", "text": "Line"},
+                    {"type": "hardBreak"},
+                    {"type": "text", "text": "Two"},
+                ],
+            },
+        ],
+    }
+
+    markdown = to_markdown(adf)
+    assert markdown == "Hello\n\nLine\nTwo"

--- a/rag-aws/services/ingest/jira_ingestor/tests/test_normalize.py
+++ b/rag-aws/services/ingest/jira_ingestor/tests/test_normalize.py
@@ -1,0 +1,103 @@
+from services.ingest.jira_ingestor.handler import normalize_issue
+
+
+def build_adf(text):
+    return {
+        "type": "doc",
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": text}],
+            }
+        ],
+    }
+
+
+def test_normalize_issue_shapes_payload():
+    description = build_adf("Example description")
+    deployment_notes = build_adf("Deployed to prod")
+    comment_body = build_adf("Looks good")
+
+    issue = {
+        "id": "2001",
+        "key": "MOB-1234",
+        "fields": {
+            "project": {"key": "MOB", "name": "Mobile"},
+            "issuetype": {"name": "Bug"},
+            "status": {"name": "In Progress"},
+            "summary": "Production incident",
+            "description": description,
+            "comment": {
+                "comments": [
+                    {
+                        "author": {"displayName": "Alice"},
+                        "created": "2025-09-15T12:00:00.000+0000",
+                        "body": comment_body,
+                    }
+                ],
+                "total": 1,
+            },
+            "issuelinks": [
+                {
+                    "type": {
+                        "name": "Relates",
+                        "outward": "relates to",
+                        "inward": "is related to",
+                    },
+                    "outwardIssue": {"key": "SRNGR-42"},
+                }
+            ],
+            "labels": ["ccc", "postmortem"],
+            "components": [{"name": "PolicyCenter"}],
+            "fixVersions": [{"name": "9/19 Release"}],
+            "reporter": {"displayName": "Reporter One"},
+            "assignee": None,
+            "created": "2025-09-10T08:00:00.000+0000",
+            "updated": "2025-09-15T12:00:00.000+0000",
+            "customfield_deploy": deployment_notes,
+        },
+    }
+
+    field_map = {"acceptance_criteria": None, "deployment_notes": "customfield_deploy"}
+    fetched_at = "2025-09-15T13:00:00Z"
+
+    normalized = normalize_issue(
+        issue,
+        field_map,
+        "https://example.atlassian.net",
+        fetched_at,
+        comments=issue["fields"]["comment"]["comments"],
+    )
+
+    assert normalized["source"] == "jira"
+    assert normalized["key"] == "MOB-1234"
+    assert normalized["project"] == "MOB"
+    assert normalized["issue_type"] == "Bug"
+    assert normalized["status"] == "In Progress"
+    assert normalized["summary"] == "Production incident"
+    assert normalized["description"]["adf"] == description
+    assert normalized["description"]["markdown"] == "Example description"
+    assert normalized["acceptance_criteria"]["adf"] is None
+    assert normalized["acceptance_criteria"]["markdown"] == ""
+    assert normalized["deployment_notes"]["adf"] == deployment_notes
+    assert normalized["deployment_notes"]["markdown"] == "Deployed to prod"
+    assert normalized["comments"] == [
+        {
+            "author": "Alice",
+            "created": "2025-09-15T12:00:00.000+0000",
+            "adf": comment_body,
+            "markdown": "Looks good",
+        }
+    ]
+    assert normalized["links"] == [
+        {"type": "relates to", "direction": "outward", "key": "SRNGR-42"}
+    ]
+    assert normalized["labels"] == ["ccc", "postmortem"]
+    assert normalized["components"] == ["PolicyCenter"]
+    assert normalized["fix_versions"] == ["9/19 Release"]
+    assert normalized["reporter"] == "Reporter One"
+    assert normalized["assignee"] is None
+    assert normalized["created"] == "2025-09-10T08:00:00.000+0000"
+    assert normalized["updated"] == "2025-09-15T12:00:00.000+0000"
+    assert normalized["uri"] == "https://example.atlassian.net/browse/MOB-1234"
+    assert normalized["fetched_at"] == fetched_at


### PR DESCRIPTION
## Summary
- provision the Jira ingestion stack with Terraform, including encrypted S3 storage, IAM role policies, and an hourly EventBridge trigger
- implement a Python 3.12 Lambda package that refreshes OAuth tokens, discovers custom fields, normalizes Jira issues, and stores raw and normalized artifacts in S3
- add developer tooling with lint/test automation, packaging helpers, and a GitHub Actions workflow to run quality gates

## Testing
- make lint
- make test
- make build

------
https://chatgpt.com/codex/tasks/task_e_68c87f8cde40832f9c8183eef67adaca